### PR TITLE
Updated composer.json to use parsedown version ~1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
     },
     "require": {
         "symfony/yaml": "~2.1",
-        "erusev/parsedown": "~0.8"
+        "erusev/parsedown": "~1.0"
     }
 }


### PR DESCRIPTION
If someone wants to use parsedown-extra as the markdown parser,
it's not possible because parsedown-extra requires parsedown ~1.0
