### PR TITLE
Flexible configuration for YAML Front Matter separators. Fixes #5

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -65,9 +65,9 @@ class Parser
         $yaml = null;
         $regex = '~^('
             .implode('|', array_map('preg_quote', $this->startSep)) # $matches[1] start separator
-            .'){1}[\r\n|\n]+(.*)[\r\n|\n]+('                        # $matches[2] between separators
+            ."){1}[\r\n|\n]*(.*)[\r\n|\n]+("                        # $matches[2] between separators
             .implode('|', array_map('preg_quote', $this->endSep))   # $matches[3] end separator
-            .'){1}[\r\n|\n]*(.*)$~s';                               # $matches[4] document content
+            ."){1}[\r\n|\n]*(.*)$~s";                               # $matches[4] document content
 
         if (preg_match($regex, $str, $matches) === 1) { // There is a Front matter
             $yaml = trim($matches[2]) !== '' ? $this->yamlParser->parse(trim($matches[2])) : null;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -41,19 +41,22 @@ class Parser
      *
      * @param string $str
      * @param bool   $parseMarkdown Should the Markdown be turned into HTML?
+     * @param string $startSep      Front matter separator start
+     * @param string $endSep        Front matter separator end
      *
      * @return Document
      */
-    public function parse($str, $parseMarkdown = true)
+    public function parse($str, $parseMarkdown = true, $startSep = '---', $endSep = '---')
     {
-        $regex = '~^[-]{3}[\r\n|\n]+(.*)[\r\n|\n]+[-]{3}~s';
+        $left = '~^'.preg_quote($startSep).'{1}[\r\n|\n]+';
+        $right = preg_quote($endSep).'{1}~s';
 
-        $hasFrontMatter = preg_match($regex, $str, $matches);
+        $hasFrontMatter = preg_match($left.'(.*)[\r\n|\n]+'.$right, $str, $matches);
 
         $yamlContent = $hasFrontMatter ? trim($matches[1]) : false;
 
         if ($yamlContent === false) {
-            $str = preg_replace('~^[-]{3}[\r\n|\n]+[-]{3}~s', '', $str, 1);
+            $str = preg_replace($left.$right, '', $str, 1);
             if ($parseMarkdown) {
                 $str = $this->markdownParser->parse($str);
             }
@@ -62,7 +65,7 @@ class Parser
 
         // There is a Front matter
         $yaml = $this->yamlParser->parse($yamlContent);
-        $content = ltrim(preg_replace($regex, '', $str, 1));
+        $content = ltrim(preg_replace($left.'(.*)[\r\n|\n]+'.$right, '', $str, 1));
 
         if ($parseMarkdown) {
             $content = $this->markdownParser->parse($content);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -30,10 +30,26 @@ class Parser
      */
     private $markdownParser;
 
-    public function __construct(YAMLParser $yamlParser = null, MarkdownParser $markdownParser = null)
-    {
+    /**
+     * @var array
+     */
+    private $startSep;
+
+    /**
+     * @var array
+     */
+    private $endSep;
+
+    public function __construct(
+        YAMLParser $yamlParser = null,
+        MarkdownParser $markdownParser = null,
+        $startSep = '---',
+        $endSep = '---'
+    ) {
         $this->yamlParser = $yamlParser ?: new SymfonyYAMLParser();
         $this->markdownParser = $markdownParser ?: new ParsedownParser();
+        $this->startSep = array_filter((array) $startSep, 'is_string') ?: array('---');
+        $this->endSep = array_filter((array) $endSep, 'is_string') ?: array('---');
     }
 
     /**
@@ -41,36 +57,23 @@ class Parser
      *
      * @param string $str
      * @param bool   $parseMarkdown Should the Markdown be turned into HTML?
-     * @param string $startSep      Front matter separator start
-     * @param string $endSep        Front matter separator end
      *
      * @return Document
      */
-    public function parse($str, $parseMarkdown = true, $startSep = '---', $endSep = '---')
+    public function parse($str, $parseMarkdown = true)
     {
-        $left = '~^'.preg_quote($startSep).'{1}[\r\n|\n]+';
-        $right = preg_quote($endSep).'{1}~s';
+        $yaml = null;
+        $regex = '~^('
+            .implode('|', array_map('preg_quote', $this->startSep)) # $matches[1] start separator
+            .'){1}[\r\n|\n]+(.*)[\r\n|\n]+('                        # $matches[2] between separators
+            .implode('|', array_map('preg_quote', $this->endSep))   # $matches[3] end separator
+            .'){1}[\r\n|\n]*(.*)$~s';                               # $matches[4] document content
 
-        $hasFrontMatter = preg_match($left.'(.*)[\r\n|\n]+'.$right, $str, $matches);
-
-        $yamlContent = $hasFrontMatter ? trim($matches[1]) : false;
-
-        if ($yamlContent === false) {
-            $str = preg_replace($left.$right, '', $str, 1);
-            if ($parseMarkdown) {
-                $str = $this->markdownParser->parse($str);
-            }
-            return new Document(null, $str);
+        if (preg_match($regex, $str, $matches) === 1) { // There is a Front matter
+            $yaml = trim($matches[2]) !== '' ? $this->yamlParser->parse(trim($matches[2])) : null;
+            $str = ltrim($matches[4]);
         }
 
-        // There is a Front matter
-        $yaml = $this->yamlParser->parse($yamlContent);
-        $content = ltrim(preg_replace($left.'(.*)[\r\n|\n]+'.$right, '', $str, 1));
-
-        if ($parseMarkdown) {
-            $content = $this->markdownParser->parse($content);
-        }
-
-        return new Document($yaml, $content);
+        return new Document($yaml, $parseMarkdown ? $this->markdownParser->parse($str) : $str);
     }
 }


### PR DESCRIPTION
See discussion on #5

YAML Front Matter separators can be set as array or strings in costructor, default to `---` for backward compatibility.

`parse()` method has now great flexibility and got also pretty simpler code.

Added a couple of unit tests.