### PR TITLE
Update dependency symfony/yaml to use "~2.1|^3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "symfony/yaml": "~2.1",
+        "symfony/yaml": "~2.1|^3.0",
         "erusev/parsedown": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
I'd like to update this Symfony Yaml dependency so I can install it globally, but it conflicts with some other packages I have which are now using version 3. I have made it optional to use ~2.1 or ^3.0 so it shouldn't even break BC. The test suite still passes too.
Thanks