### PR TITLE
Fix preg_quote to escape delimiter as well

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -63,10 +63,15 @@ class Parser
     public function parse($str, $parseMarkdown = true)
     {
         $yaml = null;
+
+        $quote = function ($str) {
+            return preg_quote($str, "~");
+        };
+
         $regex = '~^('
-            .implode('|', array_map('preg_quote', $this->startSep)) # $matches[1] start separator
-            ."){1}[\r\n|\n]*(.*?)[\r\n|\n]+("                        # $matches[2] between separators
-            .implode('|', array_map('preg_quote', $this->endSep))   # $matches[3] end separator
+            .implode('|', array_map($quote, $this->startSep)) # $matches[1] start separator
+            ."){1}[\r\n|\n]*(.*?)[\r\n|\n]+("                       # $matches[2] between separators
+            .implode('|', array_map($quote, $this->endSep))   # $matches[3] end separator
             ."){1}[\r\n|\n]*(.*)$~s";                               # $matches[4] document content
 
         if (preg_match($regex, $str, $matches) === 1) { // There is a Front matter

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -57,6 +57,18 @@ EOF;
         $this->assertEquals('', $document->getContent());
     }
 
+    public function testParseFrontYAMLPregMatchDelimiter()
+    {
+        $parser = new Parser(null, null, '~', '~');
+        $str = <<<EOF
+~
+~
+EOF;
+        $document = $parser->parse($str, false);
+        $this->assertNull($document->getYAML());
+        $this->assertEquals('', $document->getContent());
+    }
+
     public function testParseYAML()
     {
         $yamlParser = $this->getMockForAbstractClass('Mni\FrontYAML\YAML\YAMLParser');


### PR DESCRIPTION
Using the delimiter inside the quoted text would fail the regex otherwise.