### PR TITLE
Add Symfony 4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require": {
-        "symfony/yaml": "~2.1|^3.0",
+        "symfony/yaml": "~2.1|^3.0|^4.0",
         "erusev/parsedown": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hello, as noted in the #15 this patch adds optional Symfony 4 YAML component in the composer.json. From some quick tests it basically should go through ok. But probably needs thorough checking a bit more.

This is specially useful for testing current Symfony 4 BETA 1. Symfony 4 is set to be released somewhere by the end of November I think.

Thanks, for checking it out.