### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_script:
   - composer install --no-progress --prefer-source
 
 script:
-  - phpunit
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "erusev/parsedown": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~4.8.35",
         "league/commonmark": "~0.7"
     }
 }

--- a/tests/Bridge/CommonMark/CommonMarkParserTest.php
+++ b/tests/Bridge/CommonMark/CommonMarkParserTest.php
@@ -3,8 +3,9 @@
 namespace Mni\FrontYAML\Test\Bridge\CommonMark;
 
 use Mni\FrontYAML\Bridge\CommonMark\CommonMarkParser;
+use PHPUnit\Framework\TestCase;
 
-class CommonMarkParserTest extends \PHPUnit_Framework_TestCase
+class CommonMarkParserTest extends TestCase
 {
     public function testParseWithDefaultParser()
     {

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -5,11 +5,12 @@ namespace Mni\FrontYAML\Test;
 use Mni\FrontYAML\Bridge\Parsedown\ParsedownParser;
 use Mni\FrontYAML\Bridge\Symfony\SymfonyYAMLParser;
 use Mni\FrontYAML\Parser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class FunctionalTest extends \PHPUnit_Framework_TestCase
+class FunctionalTest extends TestCase
 {
 
     public function testSimpleDocument()

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -3,11 +3,12 @@
 namespace Mni\FrontYAML\Test;
 
 use Mni\FrontYAML\Parser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Mni\FrontYAML\Parser
  */
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends TestCase
 {
     public function testParseEmptyString()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.

I also updated `Travis CI` to use the installed version of `PHPUnit`, not the global one.