### PR TITLE
Document::getYAML() returns empty array instead of null when there is…

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -40,7 +40,7 @@ class Document
      */
     public function getYAML()
     {
-        return $this->yaml;
+        return isset($this->yaml) ? $this->yaml : array();
     }
 
     /**


### PR DESCRIPTION
It is much better to return an empty array than null