### PR TITLE
Authorize symfony/yaml v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/yaml": "^4.0|^5.0",
+        "symfony/yaml": "^4.0|^5.0|^6.0",
         "league/commonmark": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi :wave: 

Looking [changelog](https://github.com/symfony/yaml/blob/6.0/CHANGELOG.md) for symfony/yaml, there is no breaking change on the component, so I guess we can add this version support 