### PR TITLE
Allowing Symfony 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/yaml": "^4.0|^5.0|^6.0",
+        "symfony/yaml": "^4.0|^5.0|^6.0|^7.0",
         "league/commonmark": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
It's that time of the year again: Symfony 7 is out and [compatibility should be fine](https://github.com/symfony/yaml/blob/7.0/CHANGELOG.md#70).

Thanks! :slightly_smiling_face: 