### PR TITLE
Add type annotations

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -4,25 +4,25 @@ namespace Mni\FrontYAML;
 
 class Document
 {
-    /** @var mixed */
-    private $yaml;
+    /** @var string|array<string, mixed>|null */
+    private mixed $yaml;
 
     private string $content;
 
     /**
-     * @param mixed $yaml YAML content.
+     * @param string|array<string, mixed>|null $yaml YAML content.
      * @param string $content Content of the document.
      */
-    public function __construct($yaml, string $content)
+    public function __construct(mixed $yaml, string $content)
     {
         $this->yaml = $yaml;
         $this->content = $content;
     }
 
     /**
-     * @return mixed YAML content.
+     * @return string|array<string, mixed>|null YAML content.
      */
-    public function getYAML()
+    public function getYAML(): mixed
     {
         return $this->yaml;
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -15,12 +15,12 @@ class Parser
     /**
      * @var YAMLParser
      */
-    private $yamlParser;
+    private YAMLParser $yamlParser;
 
     /**
      * @var MarkdownParser
      */
-    private $markdownParser;
+    private MarkdownParser $markdownParser;
 
     private array $startSep;
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -27,12 +27,14 @@ class Parser
     private array $endSep;
 
     /**
+     * @param ?YAMLParser $yamlParser Set a custom YAMLParser instance. Fallback is SymfonyYAMLParser if null.
+     * @param ?MarkdownParser $markdownParser Set a custom MarkdownParser instance. Fallback is CommonMarkParser if null.
      * @param string|string[] $startSep
      * @param string|string[] $endSep
      */
     public function __construct(
-        YAMLParser $yamlParser = null,
-        MarkdownParser $markdownParser = null,
+        ?YAMLParser $yamlParser = null,
+        ?MarkdownParser $markdownParser = null,
         $startSep = '---',
         $endSep = '---'
     ) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -22,8 +22,12 @@ class Parser
      */
     private MarkdownParser $markdownParser;
 
+    /**
+     * @var string[]
+     */
     private array $startSep;
 
+    /** @var string[] */
     private array $endSep;
 
     /**

--- a/tests/Bridge/CommonMark/CommonMarkParserTest.php
+++ b/tests/Bridge/CommonMark/CommonMarkParserTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class CommonMarkParserTest extends TestCase
 {
-    public function testParseWithDefaultParser()
+    public function testParseWithDefaultParser(): void
     {
         $parser = new CommonMarkParser();
 
@@ -19,7 +19,7 @@ class CommonMarkParserTest extends TestCase
         $this->assertSame("<h1>This is a title</h1>\n", $html);
     }
 
-    public function testParseWithCustomParser()
+    public function testParseWithCustomParser(): void
     {
         $environment = new Environment;
         $environment->addExtension(new CommonMarkCoreExtension);

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class FunctionalTest extends TestCase
 {
-    public function testSimpleDocument()
+    public function testSimpleDocument(): void
     {
         $parser = new Parser;
 
@@ -23,7 +23,7 @@ EOF;
         $this->assertSame("<p>This <strong>strong</strong></p>\n", $document->getContent());
     }
 
-    public function testEscaping()
+    public function testEscaping(): void
     {
         $parser = new Parser;
 
@@ -52,7 +52,7 @@ EOF;
         $this->assertSame("<p>Foo</p>\n", $document->getContent());
     }
 
-    public function testMultilineMarkdown()
+    public function testMultilineMarkdown(): void
     {
         $parser = new Parser;
         $str = <<<EOF
@@ -69,7 +69,7 @@ EOF;
         $this->assertEquals($this->normalizeEOL($expected), $this->normalizeEOL($document->getContent()));
     }
 
-    public function testCrossOsMultiline()
+    public function testCrossOsMultiline(): void
     {
         $parser = new Parser;
         $content = <<<EOF
@@ -105,7 +105,7 @@ EOF;
         $this->assertSame($this->normalizeEOL($expectedHtml), $this->normalizeEOL($dosYaml['multiline']));
     }
 
-    public function testNonGreedySeparator()
+    public function testNonGreedySeparator(): void
     {
         $parser = new Parser;
         $content = <<<EOF
@@ -120,7 +120,7 @@ EOF;
         $this->assertSame(array('lorem' => 'ipsum'), $document->getYAML());
     }
 
-    private function normalizeEOL($str)
+    private function normalizeEOL(string $str): string
     {
         return str_replace("\r", '', $str);
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -9,7 +9,7 @@ use Mni\FrontYAML\Markdown\MarkdownParser;
 
 class ParserTest extends TestCase
 {
-    public function testParseEmptyString()
+    public function testParseEmptyString(): void
     {
         $parser = new Parser();
         $document = $parser->parse('', false);
@@ -17,7 +17,7 @@ class ParserTest extends TestCase
         $this->assertSame('', $document->getContent());
     }
 
-    public function testParseNoYAML()
+    public function testParseNoYAML(): void
     {
         $parser = new Parser();
         $document = $parser->parse('foo', false);
@@ -25,7 +25,7 @@ class ParserTest extends TestCase
         $this->assertSame('foo', $document->getContent());
     }
 
-    public function testParseNoYAML2()
+    public function testParseNoYAML2(): void
     {
         $parser = new Parser();
         $str = <<<EOF
@@ -37,7 +37,7 @@ EOF;
         $this->assertSame($str, $document->getContent());
     }
 
-    public function testParseFrontYAMLDelimiter()
+    public function testParseFrontYAMLDelimiter(): void
     {
         $parser = new Parser();
         $document = $parser->parse('---', false);
@@ -45,7 +45,7 @@ EOF;
         $this->assertSame('---', $document->getContent());
     }
 
-    public function testParseFrontYAMLDelimiters()
+    public function testParseFrontYAMLDelimiters(): void
     {
         $parser = new Parser();
         $str = <<<EOF
@@ -57,7 +57,7 @@ EOF;
         $this->assertSame('', $document->getContent());
     }
 
-    public function testParseFrontYAMLPregMatchDelimiter()
+    public function testParseFrontYAMLPregMatchDelimiter(): void
     {
         $parser = new Parser(null, null, '~', '~');
         $str = <<<EOF
@@ -69,7 +69,7 @@ EOF;
         $this->assertSame('', $document->getContent());
     }
 
-    public function testParseYAML()
+    public function testParseYAML(): void
     {
         $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
         $yamlParser->expects($this->once())
@@ -95,7 +95,7 @@ EOF;
         $this->assertSame('bim', $document->getContent());
     }
 
-    public function testParseYAMLMarkdown()
+    public function testParseYAMLMarkdown(): void
     {
         $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
         $yamlParser->expects($this->once())
@@ -123,7 +123,7 @@ EOF;
         $this->assertSame('bam', $document->getContent());
     }
 
-    public function testParseMarkdownNoYAML1Line()
+    public function testParseMarkdownNoYAML1Line(): void
     {
         $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
         $yamlParser->expects($this->never())
@@ -146,7 +146,7 @@ EOF;
         $this->assertSame('bam', $document->getContent());
     }
 
-    public function testParseMarkdownNoYAML2Lines()
+    public function testParseMarkdownNoYAML2Lines(): void
     {
         $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
         $yamlParser->expects($this->never())
@@ -169,7 +169,7 @@ EOF;
         $this->assertSame('foo', $document->getContent());
     }
 
-    public function testMarkdownParserNotCalled()
+    public function testMarkdownParserNotCalled(): void
     {
         $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
 
@@ -181,7 +181,7 @@ EOF;
         $parser->parse('foo', false);
     }
 
-    public function testParseFrontYAMLEdgeCaseDelimiters()
+    public function testParseFrontYAMLEdgeCaseDelimiters(): void
     {
         $start = '*_-\)``.|.``(/-_*';
         $end = '--({@}{._.}{@})--';
@@ -207,7 +207,7 @@ EOF;
         $this->assertSame('bim', trim($document->getContent()));
     }
 
-    public function testParseFrontYAMLArrayDelimiters()
+    public function testParseFrontYAMLArrayDelimiters(): void
     {
         $start = ['---','<!--'];
         $end = ['---','-->'];


### PR DESCRIPTION
This PR adds type annotations esp. to the `Document` type so that in apps, tools have an easier time figuring out that `$document->getYAML() ?? []` is valid.

At least in some cases -- I was surprised that `string` is also possible! So good to know, need to work around that.

- Honestly, I'm not sure how to deal with this w.r.t. releasing new versions of the package and making sure that the minimum PHP version is installed to support these annotations :)
- The test case function return type annotations of `void` were added to comply with tools to check consistency (phpstan) mostly; I don't feel strongly about adding or keeeping them out either way. Can revert that commit if you want.