### PR TITLE
fix: warning for Parser.php

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -31,8 +31,8 @@ class Parser
      * @param string|string[] $endSep
      */
     public function __construct(
-        YAMLParser $yamlParser = null,
-        MarkdownParser $markdownParser = null,
+        ?YAMLParser $yamlParser = null,
+        ?MarkdownParser $markdownParser = null,
         $startSep = '---',
         $endSep = '---'
     ) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -27,10 +27,8 @@ class Parser
     private array $endSep;
 
     /**
-     * @param YAMLParser $yamlParser (optional)
-     * @param MarkdownParser $markdownParser (optional)
-     * @param string|string[] $startSep (optional)
-     * @param string|string[] $endSep (optional)
+     * @param string|string[] $startSep
+     * @param string|string[] $endSep
      */
     public function __construct(
         ?YAMLParser $yamlParser = null,

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -27,8 +27,10 @@ class Parser
     private array $endSep;
 
     /**
-     * @param string|string[] $startSep
-     * @param string|string[] $endSep
+     * @param YAMLParser $yamlParser (optional)
+     * @param MarkdownParser $markdownParser (optional)
+     * @param string|string[] $startSep (optional)
+     * @param string|string[] $endSep (optional)
      */
     public function __construct(
         ?YAMLParser $yamlParser = null,


### PR DESCRIPTION
Silencing a warning from PHP

> WARN  Mni\FrontYAML\Parser::__construct(): Implicitly marking parameter $yamlParser as nullable is deprecated, the explicit nullable type must be used instead...

<img width="735" alt="image" src="https://github.com/user-attachments/assets/6eac4208-4ef5-48f5-815f-55278818f3a7" />
