### PR TITLE
Update to PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
         }
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "symfony/yaml": "^4.0|^5.0|^6.0|^7.0",
+        "php": "^8.2||^8.3||^8.4",
+        "symfony/yaml": "^7.0",
         "league/commonmark": "^2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^11.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,15 +2,18 @@
 <!--
     phpunit -c phpunit.xml
 -->
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="vendor/autoload.php">
+<phpunit 
+    bootstrap="vendor/autoload.php" 
+    executionOrder="depends,defects" 
+    beStrictAboutOutputDuringTests="true" 
+    failOnDeprecation="true"
+    failOnRisky="true" 
+    failOnWarning="true" 
+    colors="true" 
+    testdox="false"
+    cacheDirectory=".phpunit.cache" 
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    beStrictAboutCoverageMetadata="true">
 
     <testsuites>
         <testsuite name="Tests">

--- a/src/Bridge/CommonMark/CommonMarkParser.php
+++ b/src/Bridge/CommonMark/CommonMarkParser.php
@@ -3,7 +3,7 @@
 namespace Mni\FrontYAML\Bridge\CommonMark;
 
 use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\MarkdownConverterInterface;
+use League\CommonMark\ConverterInterface;
 use Mni\FrontYAML\Markdown\MarkdownParser;
 
 /**
@@ -11,15 +11,15 @@ use Mni\FrontYAML\Markdown\MarkdownParser;
  */
 class CommonMarkParser implements MarkdownParser
 {
-    private MarkdownConverterInterface $parser;
+    private ConverterInterface|null $parser;
 
-    public function __construct(MarkdownConverterInterface $commonMarkConverter = null)
+    public function __construct(ConverterInterface|null $commonMarkConverter = null)
     {
         $this->parser = $commonMarkConverter ?: new CommonMarkConverter;
     }
 
     public function parse(string $markdown): string
     {
-        return $this->parser->convertToHtml($markdown)->getContent();
+        return $this->parser->convert($markdown)->getContent();
     }
 }

--- a/src/Bridge/Symfony/SymfonyYAMLParser.php
+++ b/src/Bridge/Symfony/SymfonyYAMLParser.php
@@ -17,7 +17,7 @@ class SymfonyYAMLParser implements YAMLParser
         $this->parser = new Parser;
     }
 
-    public function parse(string $yaml)
+    public function parse(string $yaml): mixed
     {
         return $this->parser->parse($yaml);
     }

--- a/src/Document.php
+++ b/src/Document.php
@@ -4,8 +4,7 @@ namespace Mni\FrontYAML;
 
 class Document
 {
-    /** @var mixed */
-    private $yaml;
+    private mixed $yaml;
 
     private string $content;
 
@@ -13,7 +12,7 @@ class Document
      * @param mixed $yaml YAML content.
      * @param string $content Content of the document.
      */
-    public function __construct($yaml, string $content)
+    public function __construct(mixed $yaml, string $content)
     {
         $this->yaml = $yaml;
         $this->content = $content;
@@ -22,7 +21,7 @@ class Document
     /**
      * @return mixed YAML content.
      */
-    public function getYAML()
+    public function getYAML(): mixed
     {
         return $this->yaml;
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -12,15 +12,9 @@ use Mni\FrontYAML\YAML\YAMLParser;
  */
 class Parser
 {
-    /**
-     * @var YAMLParser
-     */
-    private $yamlParser;
+    private YAMLParser|null $yamlParser;
 
-    /**
-     * @var MarkdownParser
-     */
-    private $markdownParser;
+    private MarkdownParser|null $markdownParser;
 
     private array $startSep;
 
@@ -31,8 +25,8 @@ class Parser
      * @param string|string[] $endSep
      */
     public function __construct(
-        ?YAMLParser $yamlParser = null,
-        ?MarkdownParser $markdownParser = null,
+        YAMLParser|null $yamlParser = null,
+        MarkdownParser|null $markdownParser = null,
         $startSep = '---',
         $endSep = '---'
     ) {

--- a/src/YAML/YAMLParser.php
+++ b/src/YAML/YAMLParser.php
@@ -9,8 +9,6 @@ interface YAMLParser
 {
     /**
      * Parses a YAML string.
-     *
-     * @return mixed
      */
-    public function parse(string $yaml);
+    public function parse(string $yaml): mixed;
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -71,13 +71,13 @@ EOF;
 
     public function testParseYAML()
     {
-        $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
+        $yamlParser = $this->createMock(YAMLParser::class);
         $yamlParser->expects($this->once())
             ->method('parse')
             ->with('foo')
             ->willReturn('bar');
 
-        $markdownParser = $this->getMockForAbstractClass(MarkdownParser::class);
+        $markdownParser = $this->createMock(MarkdownParser::class);
         $markdownParser->expects($this->never())
             ->method('parse');
 
@@ -97,13 +97,13 @@ EOF;
 
     public function testParseYAMLMarkdown()
     {
-        $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
+        $yamlParser = $this->createMock(YAMLParser::class);
         $yamlParser->expects($this->once())
             ->method('parse')
             ->with('foo')
             ->willReturn('bar');
 
-        $markdownParser = $this->getMockForAbstractClass(MarkdownParser::class);
+        $markdownParser = $this->createMock(MarkdownParser::class);
         $markdownParser->expects($this->once())
             ->method('parse')
             ->with('bim')
@@ -125,11 +125,11 @@ EOF;
 
     public function testParseMarkdownNoYAML1Line()
     {
-        $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
+        $yamlParser = $this->createMock(YAMLParser::class);
         $yamlParser->expects($this->never())
             ->method('parse');
 
-        $markdownParser = $this->getMockForAbstractClass(MarkdownParser::class);
+        $markdownParser = $this->createMock(MarkdownParser::class);
         $markdownParser->expects($this->once())
             ->method('parse')
             ->with('bim')
@@ -148,11 +148,11 @@ EOF;
 
     public function testParseMarkdownNoYAML2Lines()
     {
-        $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
+        $yamlParser = $this->createMock(YAMLParser::class);
         $yamlParser->expects($this->never())
             ->method('parse');
 
-        $markdownParser = $this->getMockForAbstractClass(MarkdownParser::class);
+        $markdownParser = $this->createMock(MarkdownParser::class);
         $markdownParser->expects($this->once())
             ->method('parse')
             ->willReturn('foo');
@@ -171,9 +171,9 @@ EOF;
 
     public function testMarkdownParserNotCalled()
     {
-        $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
+        $yamlParser = $this->createMock(YAMLParser::class);
 
-        $markdownParser = $this->getMockForAbstractClass(MarkdownParser::class);
+        $markdownParser = $this->createMock(MarkdownParser::class);
         $markdownParser->expects($this->never())
             ->method('parse');
 
@@ -185,13 +185,13 @@ EOF;
     {
         $start = '*_-\)``.|.``(/-_*';
         $end = '--({@}{._.}{@})--';
-        $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
+        $yamlParser = $this->createMock(YAMLParser::class);
         $yamlParser->expects($this->once())
             ->method('parse')
             ->with('foo: bar')
             ->willReturn(['foo' => 'bar']);
 
-        $markdownParser = $this->getMockForAbstractClass(MarkdownParser::class);
+        $markdownParser = $this->createMock(MarkdownParser::class);
         $markdownParser->expects($this->never())
             ->method('parse');
 
@@ -211,13 +211,13 @@ EOF;
     {
         $start = ['---','<!--'];
         $end = ['---','-->'];
-        $yamlParser = $this->getMockForAbstractClass(YAMLParser::class);
+        $yamlParser = $this->createMock(YAMLParser::class);
         $yamlParser->expects($this->exactly(2))
             ->method('parse')
             ->with('foo: bar')
             ->willReturn(['foo' => 'bar']);
 
-        $markdownParser = $this->getMockForAbstractClass(MarkdownParser::class);
+        $markdownParser = $this->createMock(MarkdownParser::class);
         $markdownParser->expects($this->never())
             ->method('parse');
 


### PR DESCRIPTION
I've been refactoring and modernising an older code base recently and hit a wall using PHP 8.4 because of the current implementation of FrontYaml. Given that I love using it and want to continue, I've created this PR to modernise it for PHP 8.4 (and to remove explicit support for older versions that are long since EOL).

Specifically, the PR:

- Updates the required versions of PHP to be 8.2 - 8.4
- Updates the third party packages (both dev and non-dev) to be the latest version that supports PHP 8.2
- Completes adding type support throughout the library
- Removes any deprecated or soon-to-be deprecated code