### PR TITLE
fix: Remove deprecation for league/commonmark

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "symfony/yaml": "^4.0|^5.0|^6.0|^7.0|^8.0",
-        "league/commonmark": "^2.0"
+        "league/commonmark": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/src/Bridge/CommonMark/CommonMarkParser.php
+++ b/src/Bridge/CommonMark/CommonMarkParser.php
@@ -3,7 +3,7 @@
 namespace Mni\FrontYAML\Bridge\CommonMark;
 
 use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\MarkdownConverterInterface;
+use League\CommonMark\ConverterInterface;
 use Mni\FrontYAML\Markdown\MarkdownParser;
 
 /**
@@ -11,15 +11,15 @@ use Mni\FrontYAML\Markdown\MarkdownParser;
  */
 class CommonMarkParser implements MarkdownParser
 {
-    private MarkdownConverterInterface $parser;
+    private ConverterInterface $parser;
 
-    public function __construct(MarkdownConverterInterface $commonMarkConverter = null)
+    public function __construct(?ConverterInterface $commonMarkConverter = null)
     {
         $this->parser = $commonMarkConverter ?: new CommonMarkConverter;
     }
 
     public function parse(string $markdown): string
     {
-        return $this->parser->convertToHtml($markdown)->getContent();
+        return $this->parser->convert($markdown)->getContent();
     }
 }


### PR DESCRIPTION
There are deprecated notifications. I tried to fix them.

```
[DEPRECATED] Since league/commonmark 2.2.0: Calling "convertToHtml()" on a League\CommonMark\MarkdownConverter class is deprecated, use "convert()" instead. in VENDORPATH/symfony/deprecation-contracts/function.php on line 25.
```